### PR TITLE
fix: remove unused members to reduce memory usage.

### DIFF
--- a/src/stellar_types.h
+++ b/src/stellar_types.h
@@ -543,7 +543,6 @@ typedef struct {
 typedef struct {
     MuxedAccount feeSource;
     int64_t fee;
-    TransactionDetails innerTx;
 } FeeBumpTransactionDetails;
 
 typedef struct {


### PR DESCRIPTION
This member is not used, so we should remove it.