### PR TITLE
chore: update the build script to adapt to the latest SDKs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ tests-unit:
 	rm -rf tests_unit/build && cmake -Btests_unit/build -Htests_unit/ && make -C tests_unit/build/ && make -C tests_unit/build test
 
 tests-zemu:
-	./build_elfs.sh && rm -rf ./tests_zemu/elfs/stellar_nano*.elf && cp ./elfs/stellar_nano*.elf ./tests_zemu/elfs
+	./build_elfs.sh
 	cd tests_common_js && npm install && npm run build
 	cd tests_zemu && npm install && rm -rf snapshots-tmp && npm run test
 

--- a/build_elfs.sh
+++ b/build_elfs.sh
@@ -2,43 +2,26 @@
 
 set -e
 
-BUILD_FULL_PATH=$(dirname "$(realpath "$0")")
-
 # FILL THESE WITH YOUR OWN SDKs PATHS
 # NANOS_SDK=
 # NANOSP_SDK=
 # NANOX_SDK=
-
-APPNAME="stellar"
+# STAX_SDK=
 
 # list of SDKS
-NANO_SDKS=("$NANOS_SDK" "$NANOSP_SDK" "$NANOX_SDK")
-# list of target elf file name suffix
-FILE_SUFFIXES=("nanos" "nanosp" "nanox")
-
-# move to the build directory
-cd "$BUILD_FULL_PATH" || exit 1
+DEVICE_SDKS=("$NANOS_SDK" "$NANOSP_SDK" "$NANOX_SDK" "$STAX_SDK")
 
 # Do it only now since before the cd command, we might not have been inside the repository
 GIT_REPO_ROOT=$(git rev-parse --show-toplevel)
-BUILD_REL_PATH=$(realpath --relative-to="$GIT_REPO_ROOT" "$BUILD_FULL_PATH")
-
-# create elfs directory if it doesn't exist
-mkdir -p elfs
 
 # move to repo's root to build apps
 cd "$GIT_REPO_ROOT" || exit 1
 
-for ((sdk_idx=0; sdk_idx < "${#NANO_SDKS[@]}"; sdk_idx++))
-do
-    nano_sdk="${NANO_SDKS[$sdk_idx]}"
-    elf_suffix="${FILE_SUFFIXES[$sdk_idx]}"
-    echo "* Building elfs for $(basename "$nano_sdk")..."
+make clean
 
-    echo "** Building app $appname..."
-    make clean BOLOS_SDK="$nano_sdk"
-    make -j DEBUG=1 BOLOS_SDK="$nano_sdk"
-    cp bin/app.elf "$BUILD_REL_PATH/elfs/${APPNAME}_${elf_suffix}.elf"
+for sdk in "${DEVICE_SDKS[@]}"; do
+    echo "* Building elfs for $(basename "$sdk")..."
+    make -j DEBUG=1 BOLOS_SDK="$sdk"
 done
 
 echo "done"


### PR DESCRIPTION
When we run tests locally, using this script may be more convenient.